### PR TITLE
feat!: migrate to per-customer collector endpoint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,10 +3,10 @@ locals {
   enable_s3_logging            = local.enable_cloudwatch && var.s3_delivery_cloudwatch_log_stream_name != ""
   enable_http_endpoint_logging = local.enable_cloudwatch && var.http_endpoint_cloudwatch_log_stream_name != ""
   enable_kinesis_source        = var.kinesis_stream != null
-  access_key                   = format("%s %s", var.observe_customer, var.observe_token)
+  access_key                   = var.observe_token
   create_s3_bucket             = var.s3_delivery_bucket == null
   s3_bucket_arn                = local.create_s3_bucket ? aws_s3_bucket.bucket[0].arn : var.s3_delivery_bucket.arn
-  observe_url                  = var.observe_url != "" ? var.observe_url : format("https://collect.%s/v1/kinesis", var.observe_domain)
+  observe_url                  = var.observe_url != "" ? var.observe_url : format("https://%s.collect.%s/v1/kinesis", var.observe_customer, var.observe_domain)
 }
 
 resource "random_string" "bucket_suffix" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,11 @@ variable "observe_customer" {
 variable "observe_token" {
   description = "Observe Token"
   type        = string
+
+  validation {
+    condition     = contains(split("", var.observe_token), ":")
+    error_message = "Token format does not follow {datastream_id}:{datastream_secret} format."
+  }
 }
 
 variable "observe_domain" {


### PR DESCRIPTION
As part of this change, only datastream tokens will be accepted in the `observe_token` variable.

## What does this PR do?

Required - tell us about the great change you're submitting! It helps us know
what we need to review and how to collaborate on making it better.

## Motivation

Optional - delete this section if it's already obvious

## Limitations

Optional - delete this section if it's not necessary

## Testing

Required - let us know what you've done for testing so far. It helps the 
reviewer consider what more can be done to build confidence in the safety 
of the change. 
